### PR TITLE
Fix cosmwasm version typo: 1.0.10 -> 1.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "1.0.10" }
+cosmwasm-std = { package = "secret-cosmwasm-std", version = "1.1.10" }
 secret-toolkit = { version = "0.9.0", default-features = false, features = ["storage", "serialization", "utils", "permit", "viewing-key", "crypto"] }
-cosmwasm-storage = { package = "secret-cosmwasm-storage", version = "1.0.10"  }
+cosmwasm-storage = { package = "secret-cosmwasm-storage", version = "1.1.10"  }
 schemars = "0.8.12"
 serde = { version = "1.0.164", default-features = false, features = ["derive"] }
 bincode2 = "2.0.1"


### PR DESCRIPTION
Doesn't really matter as the cargo.lock picked the correct version. But, to be consistent I fixed it.